### PR TITLE
Correct format string use for err(3)

### DIFF
--- a/lscpu.c
+++ b/lscpu.c
@@ -676,7 +676,7 @@ int main(int argc, char **argv)
         mib[1] = sysctl_array[i].mib_code;
         if (sysctl(mib, ARRAY_LEN(mib), sysctl_array[i].old, &sysctl_array[i].old_len, NULL, 0) == -1)
         {
-            err(1, sysctl_array[i].err_msg);
+            err(1, "%s", sysctl_array[i].err_msg);
         }
     }
 


### PR DESCRIPTION
Fixes the following compiler error:

    clang -g -O2 -Wall -o lscpu lscpu.c
    lscpu.c:681:20: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
                err(1, sysctl_array[i].err_msg);
                       ^~~~~~~~~~~~~~~~~~~~~~~
    lscpu.c:681:20: note: treat the string as an argument to avoid this
                err(1, sysctl_array[i].err_msg);
                       ^
                       "%s",
    1 warning generated.